### PR TITLE
Increase default timeout to 15000

### DIFF
--- a/lib/BizOpsClient.js
+++ b/lib/BizOpsClient.js
@@ -10,7 +10,7 @@ const createTransport = require('./createTransport');
  * @property {String} [systemCode] - A Biz Ops system code which identifies your service
  * @property {String} [userID] - A user ID which identifies who is making a request
  * @property {String} [host="https://api.ft.com/biz-ops"] - API key for the FT API Gateway
- * @property {Number} [timeout=8000] - Maximum time in ms to wait for a response
+ * @property {Number} [timeout=15000] - Maximum time in ms to wait for a response
  */
 
 /**
@@ -23,7 +23,7 @@ const createTransport = require('./createTransport');
  */
 const defaultOptions = {
 	host: 'https://api.ft.com/biz-ops',
-	timeout: 8000,
+	timeout: 15000,
 };
 
 class BizOpsClient {


### PR DESCRIPTION
## Why?

The API timeout is 15 seconds, and big GraphQL queries can take a while, as can hefty writes (although the queries are a lot better optimised than they used to be, so I don't think we get close to this limit much, if at all, nowadays)
