### PR TITLE
Advise not to change rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ Once initialised the Biz Ops client provides [methods](#api) to send and retriev
 
 The `BizOpsClient` class accepts the following parameters:
 
-| Option       | Type   | Required | Description                                                             |
-| ------------ | ------ | -------- | ----------------------------------------------------------------------- |
-| `apiKey`     | String | Yes      | API key for the [FT API Gateway](http://developer.ft.com)               |
-| `systemCode` | String | Yes\*    | A Biz Ops system code which identifies the service making requests.     |
-| `userID`     | String | Yes\*    | A user ID which identifies who is making a request                      |
-| `host`       | String |          | URL for the Biz Ops API, defaults to `"https://api.ft.com/biz-ops"`.    |
-| `timeout`    | Number |          | Maximum time in milliseconds to wait for a response, defaults to `8000` |
-| `rps`        | Number |          | Maximum number of API requests per second, defaults to `18`             |
+| Option       | Type   | Required | Description                                                                                         |
+| ------------ | ------ | -------- | --------------------------------------------------------------------------------------------------- |
+| `apiKey`     | String | Yes      | API key for the [FT API Gateway](http://developer.ft.com)                                           |
+| `systemCode` | String | Yes\*    | A Biz Ops system code which identifies the service making requests.                                 |
+| `userID`     | String | Yes\*    | A user ID which identifies who is making a request                                                  |
+| `host`       | String |          | URL for the Biz Ops API, defaults to `"https://api.ft.com/biz-ops"`.                                |
+| `timeout`    | Number |          | Maximum time in milliseconds to wait for a response, defaults to `8000`                             |
+| `rps`        | Number |          | Maximum number of API requests per second, defaults to `18` - highly recommended not to change this |
 
 \* you must configure at least one of `systemCode` or `userID`.
 


### PR DESCRIPTION
## Why?

next-service-registry was setting to a higher value - nothing to recommend against it

## What?

Update README.md