### PR TITLE
allow passing force=true in delete calls

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,4 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.13.5
+ignore: {}
+patch: {}

--- a/README.md
+++ b/README.md
@@ -110,9 +110,13 @@ This method also accepts additional URL parameters to be set:
 -   `unlockFields` a list of fields to enable any system to write these fields, see [field locking] for more information.
 -   `relationshipAction` either `"merge"` or `"replace"` which specifies the behaviour when modifying relationships.
 
-#### `node.delete(type: string, code: string)`
+#### `node.delete(type: string, code: string, params?: object)`
 
 Deletes an existing record. Resolves to `true` if the request is successful. Rejects with a [`NotFound`](#errors) error if the requested record cannot be found or a [`Conflict`](#errors) error if the record cannot be deleted.
+
+This method also accepts additional URL parameters to be set:
+
+-   `force` a boolean which allows the deletion of a node even if it has relationships
 
 [schema]: https://github.com/Financial-Times/biz-ops-schema/tree/master/schema
 [field locking]: https://github.com/Financial-Times/biz-ops-api/blob/master/ENDPOINTS.md#field-locking

--- a/lib/api/__tests__/node.test.js
+++ b/lib/api/__tests__/node.test.js
@@ -159,6 +159,17 @@ describe('lib/api/node', () => {
 			);
 		});
 
+		it('appends a params as a query string', async () => {
+			makeRequestMock.mockResolvedValue({});
+
+			await api.delete('Type', 'Code', { force: true });
+
+			expect(makeRequestMock).toHaveBeenCalledWith(
+				'/v2/node/Type/Code?force=true',
+				expect.any(Object),
+			);
+		});
+
 		it('resolves with a boolean when successful', async () => {
 			makeRequestMock.mockResolvedValue({});
 

--- a/lib/api/node.js
+++ b/lib/api/node.js
@@ -71,12 +71,15 @@ function buildNode(options) {
 	 * Make a Biz Ops API DELETE request to destroy an existing record
 	 * @param {String} type
 	 * @param {String} code
+	 * @param {Object} [params={}] - additional query string parameters
+	 * @param {Boolean} [params.force] - allow the deletion of a node even if it has relationships
 	 * @returns {Promise<Boolean>}
 	 */
-	async function nodeDelete(type, code) {
+	async function nodeDelete(type, code, params = {}) {
 		code = encodeURIComponent(code);
+		const qs = queryString(params);
 
-		await makeRequest(`/v2/node/${type}/${code}`, {
+		await makeRequest(`/v2/node/${type}/${code}${qs ? '?' : ''}${qs}`, {
 			method: 'DELETE',
 		});
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6919,9 +6919,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "http-errors": "^1.8.0",
     "mixin-deep": "^2.0.1",
-    "node-fetch": "^2.6.0",
+    "node-fetch": "^2.6.1",
     "p-ratelimit": "^0.11.0",
     "url-join": "^4.0.0"
   },


### PR DESCRIPTION
## Why?

The API now allows sending force=true to delete requests
## What?
- adds a params object to `delete`
- documents and tests it