### PR TITLE
removed logger to be released as v0.8.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Thrown when responses from the GraphQL API include any [errors](https://github.c
 This example demonstrates how to catch and log an error when a GraphQL query fails. Note that this example uses `return await` to ensure that exceptions are caught by the `catch` block defined in the function below.
 
 ```js
-const logger = require('@dotcom-reliability-kit/logger');
+const nLogger = require('@financial-times/n-logger').default;
 const { BizOpsClient } = require('@financial-times/biz-ops-client');
 
 const client = new BizOpsClient({
@@ -163,7 +163,7 @@ async function bizOpsQuery(query) {
 	try {
 		return await client.graphQL.post(query);
 	} catch (error) {
-		logger.error(error, {
+		nLogger.error(error, {
 			event: 'BIZ_OPS_QUERY_FAILED',
 		});
 		return Promise.reject(error);

--- a/lib/makeRequest.js
+++ b/lib/makeRequest.js
@@ -1,6 +1,5 @@
 const fetch = require('node-fetch').default;
 const createError = require('http-errors');
-const logger = require('@dotcom-reliability-kit/logger');
 
 /**
  * Make HTTP request
@@ -10,13 +9,6 @@ const logger = require('@dotcom-reliability-kit/logger');
  * @throws {HTTPError} Will throw an HTTP error for non-200 responses
  */
 async function makeRequest(url, init = {}) {
-	logger.debug({
-		event: 'SENDING_REQUEST_TO_BIZ_OPS_API',
-		'client-id': init.headers?.['client-id'],
-		'client-user-id': init.headers?.['client-user-id'],
-		url,
-		method: init.method || 'GET',
-	});
 	const response = await fetch(url, init);
 
 	const contentType = response.headers.get('Content-Type');

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "devDependencies": {
     "@financial-times/rel-engage": "^8.0.7",
     "@types/jest": "^26.0.20",
-    "jest": "^28.1.0"
+    "jest": "^28.1.0",
+    "nock": "^13.0.7"
   },
   "dependencies": {
     "bottleneck": "^2.19.5",

--- a/package.json
+++ b/package.json
@@ -21,12 +21,9 @@
   "devDependencies": {
     "@financial-times/rel-engage": "^8.0.7",
     "@types/jest": "^26.0.20",
-    "jest": "^28.1.0",
-    "nock": "^13.0.7",
-    "pino-pretty": "^10.0.0"
+    "jest": "^28.1.0"
   },
   "dependencies": {
-    "@dotcom-reliability-kit/logger": "^1.0.3",
     "bottleneck": "^2.19.5",
     "http-errors": "^1.8.0",
     "mixin-deep": "^2.0.1",


### PR DESCRIPTION
> ## Why?
> 
> -   need to switch v0 of the client to use bottleneck to prevent 429s
> 
> ## What?
> 
> -  I have removed the logger from the latest version of the client to be released with tag v0.8.5

We have decided instead to temporarily remove the logger from the client until the conflict issues between n-logger and dotcom-logger are resolved