### PR TITLE
document error handling to match the current api beehaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,11 +79,11 @@ All methods return a promise. If the API responds with an unsuccessful (non-20x)
 
 #### `graphQL.get(query: string, variables?: object, strict?: boolean)`
 
-Fetches data from the Biz Ops GraphQL API using a `GET` request. You should use this if data does not need to be up-to-date. Resolves to the data returned. Rejects with a [`BadRequest`](#errors) if the query is invalid. When "strict mode" is enabled the promise will also be rejected with a [`GraphQLError`](#errors) if a successful response includes any errors.
+Fetches data from the Biz Ops GraphQL API using a `GET` request. You should use this if data does not need to be up-to-date. Resolves to the data returned. If the server responds with a http error then this method rejects with the equivalent error provided by the [http-errors library](https://www.npmjs.com/package/http-errors#list-of-all-constructors). When "strict mode" is enabled the promise will also be rejected with a [`GraphQLError`](#errors) if a successful response includes any errors.
 
 #### `graphQL.post(query: string, variables?: object, strict?: boolean)`
 
-Fetches data from the Biz Ops GraphQL API using a `POST` request. You should use this if data must always be up-to-date. Resolves to the data returned. Rejects with a [`BadRequest`](#errors) if the query is invalid. When "strict mode" is enabled the promise will also be rejected with a [`GraphQLError`](#errors) if a successful response includes any errors.
+Fetches data from the Biz Ops GraphQL API using a `POST` request. You should use this if data must always be up-to-date. Resolves to the data returned. If the server responds with a http error then this method rejects with the equivalent error provided by the [http-errors library](https://www.npmjs.com/package/http-errors#list-of-all-constructors). When "strict mode" is enabled the promise will also be rejected with a [`GraphQLError`](#errors) if a successful response includes any errors.
 
 #### `node.head(type: string, code: string)`
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Fetches data from the Biz Ops GraphQL API using a `GET` request. You should use 
 
 Fetches data from the Biz Ops GraphQL API using a `POST` request. You should use this if data must always be up-to-date. Resolves to the data returned. If the server responds with a http error then this method rejects with the equivalent error provided by the [http-errors library](https://www.npmjs.com/package/http-errors#list-of-all-constructors). When "strict mode" is enabled the promise will also be rejected with a [`GraphQLError`](#errors) if a successful response includes any errors.
 
+> Note that GraphQL error handling may not align with your expectations if you're used to working with REST. Our server complies with the draft GraphQL over Http spec, and [here you can see examples of types of errors and responses](https://github.com/graphql/graphql-over-http/blob/main/spec/GraphQLOverHTTP.md#examples)
+
 #### `node.head(type: string, code: string)`
 
 Verifies if a record exists. Resolves to `true` if the request is successful. Rejects with a [`NotFound`](#errors) error if the requested record cannot be found.


### PR DESCRIPTION
## Why?

We upgraded some API libraries which means the way it treats errors in GraphQL queries is a bit different - now it serves an error via the `errors` array, when previously it responded 400.

## What?
Changes the docs to be less specific about the situations taht cause different kind of errors. Now it just says that it essentially passes on http errors to the user