### PR TITLE
Throw when data is undefined regardless of strict flag

### DIFF
--- a/lib/api/__tests__/graphQL.test.js
+++ b/lib/api/__tests__/graphQL.test.js
@@ -56,6 +56,46 @@ describe('lib/api/graphQL', () => {
 				expect.objectContaining({ name: 'GraphQLError' }),
 			);
 		});
+
+		it('rejects when returned data is undefined and strict is true', async () => {
+			makeRequestMock.mockResolvedValue({
+				data: undefined,
+				errors: [{ message: 'Oh, mate' }],
+			});
+
+			// eslint-disable-next-line unicorn/consistent-function-scoping
+			const run = () => api.get('{ query }', null, true);
+
+			await expect(run).rejects.toThrowError(
+				expect.objectContaining({ name: 'GraphQLError' }),
+			);
+		});
+
+		it('still rejects when returned data is undefined if strict is false', async () => {
+			makeRequestMock.mockResolvedValue({
+				data: undefined,
+				errors: [{ message: 'Oh, mate' }],
+			});
+
+			// eslint-disable-next-line unicorn/consistent-function-scoping
+			const run = () => api.get('{ query }', null);
+
+			await expect(run).rejects.toThrowError(
+				expect.objectContaining({ name: 'GraphQLError' }),
+			);
+		});
+
+		it('doesnt reject when returned data is empty', async () => {
+			makeRequestMock.mockResolvedValue({
+				data: [],
+				errors: [{ message: 'no  problem here!' }],
+			});
+
+			// eslint-disable-next-line unicorn/consistent-function-scoping
+			const result = await api.get('{ query }', null);
+
+			expect(result).toEqual([]);
+		});
 	});
 
 	describe('.post()', () => {

--- a/lib/api/__tests__/graphQL.test.js
+++ b/lib/api/__tests__/graphQL.test.js
@@ -59,7 +59,6 @@ describe('lib/api/graphQL', () => {
 
 		it('rejects when returned data is undefined and strict is true', async () => {
 			makeRequestMock.mockResolvedValue({
-				data: undefined,
 				errors: [{ message: 'Oh, mate' }],
 			});
 
@@ -73,7 +72,6 @@ describe('lib/api/graphQL', () => {
 
 		it('still rejects when returned data is undefined if strict is false', async () => {
 			makeRequestMock.mockResolvedValue({
-				data: undefined,
 				errors: [{ message: 'Oh, mate' }],
 			});
 
@@ -87,14 +85,14 @@ describe('lib/api/graphQL', () => {
 
 		it('doesnt reject when returned data is empty', async () => {
 			makeRequestMock.mockResolvedValue({
-				data: [],
+				data: { empty: [] },
 				errors: [{ message: 'no  problem here!' }],
 			});
 
 			// eslint-disable-next-line unicorn/consistent-function-scoping
 			const result = await api.get('{ query }', null);
 
-			expect(result).toEqual([]);
+			expect(result).toEqual({ empty: [] });
 		});
 	});
 

--- a/lib/api/graphQL.js
+++ b/lib/api/graphQL.js
@@ -54,7 +54,8 @@ function buildGraphQL(options) {
 		/** @type {GraphQLResponse} */
 		const result = await makeRequest(`/graphql?${qs}`, { method: 'GET' });
 
-		return strict || !result?.data ? throwOnErrors(result) : result.data;
+		if (!result.data) throwOnErrors(result);
+		return strict ? throwOnErrors(result) : result.data;
 	}
 
 	/**
@@ -73,7 +74,8 @@ function buildGraphQL(options) {
 		/** @type {GraphQLResponse} */
 		const result = await makeRequest('/graphql', { method: 'POST', body });
 
-		return strict || !result?.data ? throwOnErrors(result) : result.data;
+		if (!result.data) throwOnErrors(result);
+		return strict ? throwOnErrors(result) : result.data;
 	}
 
 	return { get, post };

--- a/lib/api/graphQL.js
+++ b/lib/api/graphQL.js
@@ -54,7 +54,7 @@ function buildGraphQL(options) {
 		/** @type {GraphQLResponse} */
 		const result = await makeRequest(`/graphql?${qs}`, { method: 'GET' });
 
-		return strict ? throwOnErrors(result) : result.data;
+		return strict || !result?.data ? throwOnErrors(result) : result.data;
 	}
 
 	/**
@@ -73,7 +73,7 @@ function buildGraphQL(options) {
 		/** @type {GraphQLResponse} */
 		const result = await makeRequest('/graphql', { method: 'POST', body });
 
-		return strict ? throwOnErrors(result) : result.data;
+		return strict || !result?.data ? throwOnErrors(result) : result.data;
 	}
 
 	return { get, post };


### PR DESCRIPTION
## Why?

-   Query syntax errors are being swallowed when `strict` is not provided.
- `data` is being returned as `undefined` with no `errors` object

## What?

-   Force errors to be thrown, regardless of the `strict` flag, if syntax errors cause the data to be undefined.
- Note that an empty data array is allowed and its not the same as `undefined`; that just means the query syntax was ok but no data was found.

### Anything in particular you'd like to highlight to reviewers?
No