### PR TITLE
EI-4617 - Update node engines support to v18 and above

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,13 +16,13 @@
         "url-join": "^4.0.0"
       },
       "devDependencies": {
-        "@financial-times/rel-engage": "^8.0.9",
+        "@financial-times/rel-engage": "^9.1.0",
         "@types/jest": "^26.0.20",
         "jest": "^28.1.0",
         "nock": "^13.0.7"
       },
       "engines": {
-        "node": ">= 18"
+        "node": "18"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -673,9 +673,9 @@
       "dev": true
     },
     "node_modules/@financial-times/rel-engage": {
-      "version": "8.0.9",
-      "resolved": "https://registry.npmjs.org/@financial-times/rel-engage/-/rel-engage-8.0.9.tgz",
-      "integrity": "sha512-NGSK1cnqczlMIEQvZaZs8hoQ8SHBBYe0Nc9Xur6LJjM+0PTJmMO2mra/TMIYj1sXuHhk+8pyo3+sEDurYi5wFQ==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@financial-times/rel-engage/-/rel-engage-9.1.0.tgz",
+      "integrity": "sha512-fZus8jftwwycaXGrXoBT43dsaWwNwI7SbUYJy2zEsN8Vfty92lNGbDhtqjqOqVlNyZw592PElISeduOTKf7CKg==",
       "dev": true,
       "dependencies": {
         "@financial-times/secret-squirrel": "^2.13.0",
@@ -697,10 +697,8 @@
         "execa": "^4.0.0",
         "husky": "^4.3.8",
         "lint-staged": "^10.5.4",
-        "node-fetch": "^2.6.0",
         "prettier": "^2.0.5",
-        "read-pkg-up": "^7.0.0",
-        "yargs": "^15.4.1"
+        "read-pkg-up": "^7.0.0"
       },
       "bin": {
         "rel-engage": "bin/init.js"
@@ -2125,43 +2123,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "dev": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cliui/node_modules/wrap-ansi": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2304,15 +2265,6 @@
         "supports-color": {
           "optional": true
         }
-      }
-    },
-    "node_modules/decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/dedent": {
@@ -7029,12 +6981,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/require-main-filename": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-      "dev": true
-    },
     "node_modules/require-uncached": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-2.0.0.tgz",
@@ -7245,12 +7191,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/set-blocking": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
-      "dev": true
     },
     "node_modules/set-function-name": {
       "version": "2.0.1",
@@ -8213,12 +8153,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/which-module": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
-      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
-      "dev": true
-    },
     "node_modules/which-pm-runs": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz",
@@ -8316,12 +8250,6 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
-    "node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "dev": true
-    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -8335,41 +8263,6 @@
       "dev": true,
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
-        "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "dev": true,
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/Financial-Times/biz-ops-client",
   "devDependencies": {
-    "@financial-times/rel-engage": "^8.0.9",
+    "@financial-times/rel-engage": "^9.1.0",
     "@types/jest": "^26.0.20",
     "jest": "^28.1.0",
     "nock": "^13.0.7"
@@ -32,7 +32,7 @@
     "url-join": "^4.0.0"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 18"
   },
   "volta": {
     "node": "18.18.0",


### PR DESCRIPTION
## Why?

-  NodeJS v14 is no longer supported - PH [record](https://problem-hub.in.ft.com/problem/biz-ops-api%3Aproblem%3ARepository%3Agithub%3AFinancial-Times%2Fbiz-ops-client%3ArepositoriesWhichReferenceUnsupportedRuntimeCyberEssentials2024/Active)

## What?

- Sets the engines to node v18 and above
- Updates @financial-times/rel-engage to the latest version
