### PR TITLE
Allow endpoints to versioned

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ The `BizOpsClient` class accepts the following parameters:
 
 \* you must configure at least one of `systemCode` or `userID`.
 
-\*\* once in a while when we carry out a migration/upgrade we may ask you to use a versioned endpoint during the transition period. e.g. `graphqlEndpoint='/graphqlV5'`
+\*\* once in a while when we carry out a migration/upgrade we may ask you to use a versioned endpoint during the transition period. e.g. `graphqlEndpoint='/v3/graphql'`
 
 ### API
 

--- a/README.md
+++ b/README.md
@@ -62,16 +62,20 @@ Once initialised the Biz Ops client provides [methods](#api) to send and retriev
 
 The `BizOpsClient` class accepts the following parameters:
 
-| Option       | Type   | Required | Description                                                                                         |
-| ------------ | ------ | -------- | --------------------------------------------------------------------------------------------------- |
-| `apiKey`     | String | Yes      | API key for the [FT API Gateway](http://developer.ft.com)                                           |
-| `systemCode` | String | Yes\*    | A Biz Ops system code which identifies the service making requests.                                 |
-| `userID`     | String | Yes\*    | A user ID which identifies who is making a request                                                  |
-| `host`       | String |          | URL for the Biz Ops API, defaults to `"https://api.ft.com/biz-ops"`.                                |
-| `timeout`    | Number |          | Maximum time in milliseconds to wait for a response, defaults to `15000`                            |
-| `rps`        | Number |          | Maximum number of API requests per second, defaults to `18` - highly recommended not to change this |
+| Option            | Type   | Required | Description                                                                                         |
+| ----------------- | ------ | -------- | --------------------------------------------------------------------------------------------------- |
+| `apiKey`          | String | Yes      | API key for the [FT API Gateway](http://developer.ft.com)                                           |
+| `systemCode`      | String | Yes\*    | A Biz Ops system code which identifies the service making requests.                                 |
+| `userID`          | String | Yes\*    | A user ID which identifies who is making a request                                                  |
+| `host`            | String |          | URL for the Biz Ops API, defaults to `"https://api.ft.com/biz-ops"`.                                |
+| `nodeEndpoint`    | String | \*\*     | URL for the Biz Ops API node requests, defaults to `/v2/node`.                                      |
+| `graphqlEndpoint` | String | \*\*     | URL for the Biz Ops API graphql requests, defaults to `/graphql`.                                   |
+| `timeout`         | Number |          | Maximum time in milliseconds to wait for a response, defaults to `15000`                            |
+| `rps`             | Number |          | Maximum number of API requests per second, defaults to `18` - highly recommended not to change this |
 
 \* you must configure at least one of `systemCode` or `userID`.
+
+\*\* once in a while when we carry out a migration/upgrade we may ask you to use a versioned endpoint during the transition period. e.g. `graphqlEndpoint='/graphqlV5'`
 
 ### API
 

--- a/lib/BizOpsClient.js
+++ b/lib/BizOpsClient.js
@@ -31,6 +31,8 @@ const { createAgent, createQueue } = require('./internals');
  */
 const defaultOptions = {
 	host: 'https://api.ft.com/biz-ops',
+	nodeEndpoint: '/v2/node',
+	graphQlEndpoint: '/graphql',
 	timeout: 15000,
 	rps: 18,
 };
@@ -69,9 +71,15 @@ class BizOpsClient {
 
 		// The API methods are attached manually to ensure that all
 		// JSDoc/TypeScript type information can be inferred.
-		this.node = buildNode(apiFactoryOptions);
-		this.nodeAbsorb = buildNodeAbsorb(apiFactoryOptions);
-		this.graphQL = buildGraphQL(apiFactoryOptions);
+		this.node = buildNode(this.options.nodeEndpoint, apiFactoryOptions);
+		this.nodeAbsorb = buildNodeAbsorb(
+			this.options.nodeEndpoint,
+			apiFactoryOptions,
+		);
+		this.graphQL = buildGraphQL(
+			this.options.graphQlEndpoint,
+			apiFactoryOptions,
+		);
 	}
 
 	/**

--- a/lib/BizOpsClient.js
+++ b/lib/BizOpsClient.js
@@ -32,7 +32,7 @@ const { createAgent, createQueue } = require('./internals');
 const defaultOptions = {
 	host: 'https://api.ft.com/biz-ops',
 	nodeEndpoint: '/v2/node',
-	graphQlEndpoint: '/graphql',
+	graphqlEndpoint: '/graphql',
 	timeout: 15000,
 	rps: 18,
 };
@@ -77,7 +77,7 @@ class BizOpsClient {
 			apiFactoryOptions,
 		);
 		this.graphQL = buildGraphQL(
-			this.options.graphQlEndpoint,
+			this.options.graphqlEndpoint,
 			apiFactoryOptions,
 		);
 	}

--- a/lib/api/__tests__/graphQL.test.js
+++ b/lib/api/__tests__/graphQL.test.js
@@ -2,7 +2,7 @@ const subject = require('../graphQL');
 
 describe('lib/api/graphQL', () => {
 	const makeRequestMock = jest.fn();
-	const api = subject({ makeRequest: makeRequestMock });
+	const api = subject('/graphql', { makeRequest: makeRequestMock });
 
 	afterEach(() => {
 		makeRequestMock.mockReset();

--- a/lib/api/__tests__/node.test.js
+++ b/lib/api/__tests__/node.test.js
@@ -2,7 +2,7 @@ const subject = require('../node');
 
 describe('lib/api/node', () => {
 	const makeRequestMock = jest.fn();
-	const api = subject({ makeRequest: makeRequestMock });
+	const api = subject('/v2/node', { makeRequest: makeRequestMock });
 
 	afterEach(() => {
 		makeRequestMock.mockReset();

--- a/lib/api/graphQL.js
+++ b/lib/api/graphQL.js
@@ -1,3 +1,4 @@
+const urlJoin = require('url-join');
 const { GraphQLError } = require('../errors');
 const queryString = require('../utils/queryString');
 
@@ -53,7 +54,8 @@ function buildGraphQL(baseUrl, options) {
 		});
 
 		/** @type {GraphQLResponse} */
-		const result = await makeRequest(`${baseUrl}?${qs}`, { method: 'GET' });
+		const url = urlJoin(baseUrl, `?${qs}`);
+		const result = await makeRequest(url, { method: 'GET' });
 
 		if (!result.data) throwOnErrors(result);
 		return strict ? throwOnErrors(result) : result.data;

--- a/lib/api/graphQL.js
+++ b/lib/api/graphQL.js
@@ -34,7 +34,7 @@ function throwOnErrors(result) {
 }
 
 /**
- * @param {string} baseUrl - the base url for graphql actions. Will be '/graphql' if no client options were provided.
+ * @param {string} baseUrl - the base url for graphql actions. Will default to '/graphql' if no `graphqlEndpoint` option is provided.
  * @param {import('../BizOpsClient').FactoryOptions} options
  */
 function buildGraphQL(baseUrl, options) {

--- a/lib/api/graphQL.js
+++ b/lib/api/graphQL.js
@@ -33,9 +33,10 @@ function throwOnErrors(result) {
 }
 
 /**
+ * @param {string} baseUrl - the base url for graphql actions. Will be '/graphql' if no client options were provided.
  * @param {import('../BizOpsClient').FactoryOptions} options
  */
-function buildGraphQL(options) {
+function buildGraphQL(baseUrl, options) {
 	const { makeRequest } = options;
 
 	/**
@@ -52,7 +53,7 @@ function buildGraphQL(options) {
 		});
 
 		/** @type {GraphQLResponse} */
-		const result = await makeRequest(`/graphql?${qs}`, { method: 'GET' });
+		const result = await makeRequest(`${baseUrl}?${qs}`, { method: 'GET' });
 
 		if (!result.data) throwOnErrors(result);
 		return strict ? throwOnErrors(result) : result.data;
@@ -72,7 +73,7 @@ function buildGraphQL(options) {
 		});
 
 		/** @type {GraphQLResponse} */
-		const result = await makeRequest('/graphql', { method: 'POST', body });
+		const result = await makeRequest(baseUrl, { method: 'POST', body });
 
 		if (!result.data) throwOnErrors(result);
 		return strict ? throwOnErrors(result) : result.data;

--- a/lib/api/node.js
+++ b/lib/api/node.js
@@ -1,3 +1,4 @@
+const urlJoin = require('url-join');
 const queryString = require('../utils/queryString');
 
 /**
@@ -16,7 +17,8 @@ function buildNode(baseUrl, options) {
 	async function nodeHead(type, code) {
 		code = encodeURIComponent(code);
 
-		await makeRequest(`${baseUrl}/${type}/${code}`, {
+		const url = urlJoin(baseUrl, type, code);
+		await makeRequest(url, {
 			method: 'HEAD',
 		});
 
@@ -39,7 +41,8 @@ function buildNode(baseUrl, options) {
 
 		const qs = queryString(params);
 
-		return makeRequest(`${baseUrl}/${type}/${code}${qs ? '?' : ''}${qs}`, {
+		const url = urlJoin(baseUrl, type, code, `${qs ? '?' : ''}${qs}`);
+		return makeRequest(url, {
 			method: 'POST',
 			body: JSON.stringify(body),
 		});
@@ -62,7 +65,8 @@ function buildNode(baseUrl, options) {
 
 		const qs = queryString(params);
 
-		return makeRequest(`${baseUrl}/${type}/${code}${qs ? '?' : ''}${qs}`, {
+		const url = urlJoin(baseUrl, type, code, `${qs ? '?' : ''}${qs}`);
+		return makeRequest(url, {
 			method: 'PATCH',
 			body: JSON.stringify(body),
 		});
@@ -80,7 +84,8 @@ function buildNode(baseUrl, options) {
 		code = encodeURIComponent(code);
 		const qs = queryString(params);
 
-		await makeRequest(`${baseUrl}/${type}/${code}${qs ? '?' : ''}${qs}`, {
+		const url = urlJoin(baseUrl, type, code, `${qs ? '?' : ''}${qs}`);
+		await makeRequest(url, {
 			method: 'DELETE',
 		});
 

--- a/lib/api/node.js
+++ b/lib/api/node.js
@@ -1,9 +1,10 @@
 const queryString = require('../utils/queryString');
 
 /**
+ * @param {string} baseUrl - the base url for node actions. Will be '/v2/node' if no client options were provided.
  * @param {import('../BizOpsClient').FactoryOptions} options
  */
-function buildNode(options) {
+function buildNode(baseUrl, options) {
 	const { makeRequest } = options;
 
 	/**
@@ -15,7 +16,7 @@ function buildNode(options) {
 	async function nodeHead(type, code) {
 		code = encodeURIComponent(code);
 
-		await makeRequest(`/v2/node/${type}/${code}`, {
+		await makeRequest(`${baseUrl}/${type}/${code}`, {
 			method: 'HEAD',
 		});
 
@@ -38,7 +39,7 @@ function buildNode(options) {
 
 		const qs = queryString(params);
 
-		return makeRequest(`/v2/node/${type}/${code}${qs ? '?' : ''}${qs}`, {
+		return makeRequest(`${baseUrl}/${type}/${code}${qs ? '?' : ''}${qs}`, {
 			method: 'POST',
 			body: JSON.stringify(body),
 		});
@@ -61,7 +62,7 @@ function buildNode(options) {
 
 		const qs = queryString(params);
 
-		return makeRequest(`/v2/node/${type}/${code}${qs ? '?' : ''}${qs}`, {
+		return makeRequest(`${baseUrl}/${type}/${code}${qs ? '?' : ''}${qs}`, {
 			method: 'PATCH',
 			body: JSON.stringify(body),
 		});
@@ -79,7 +80,7 @@ function buildNode(options) {
 		code = encodeURIComponent(code);
 		const qs = queryString(params);
 
-		await makeRequest(`/v2/node/${type}/${code}${qs ? '?' : ''}${qs}`, {
+		await makeRequest(`${baseUrl}/${type}/${code}${qs ? '?' : ''}${qs}`, {
 			method: 'DELETE',
 		});
 

--- a/lib/api/node.js
+++ b/lib/api/node.js
@@ -2,7 +2,7 @@ const urlJoin = require('url-join');
 const queryString = require('../utils/queryString');
 
 /**
- * @param {string} baseUrl - the base url for node actions. Will be '/v2/node' if no client options were provided.
+ * @param {string} baseUrl - the base url for node actions. Will default to '/v2/node' if no `nodeEndpoint` option is provided.
  * @param {import('../BizOpsClient').FactoryOptions} options
  */
 function buildNode(baseUrl, options) {

--- a/lib/api/nodeAbsorb.js
+++ b/lib/api/nodeAbsorb.js
@@ -1,7 +1,7 @@
 const urlJoin = require('url-join');
 
 /**
- * @param {string} baseUrl - the base url for absorb actions. Will be sent as '/v2/node' if no client options were provided.
+ * @param {string} baseUrl - the base url for absorb actions. Will default to '/v2/node' if no `nodeEndpoint` option is provided.
  * @param {import('../BizOpsClient').FactoryOptions} options
  */
 function buildNodeAbsorb(baseUrl, options) {

--- a/lib/api/nodeAbsorb.js
+++ b/lib/api/nodeAbsorb.js
@@ -1,3 +1,5 @@
+const urlJoin = require('url-join');
+
 /**
  * @param {string} baseUrl - the base url for absorb actions. Will be sent as '/v2/node' if no client options were provided.
  * @param {import('../BizOpsClient').FactoryOptions} options
@@ -16,12 +18,10 @@ function buildNodeAbsorb(baseUrl, options) {
 		targetCode = encodeURIComponent(targetCode);
 		sourceCode = encodeURIComponent(sourceCode);
 
-		return makeRequest(
-			`${baseUrl}/${type}/${targetCode}/absorb/${sourceCode}`,
-			{
-				method: 'POST',
-			},
-		);
+		const url = urlJoin(baseUrl, type, targetCode, 'absorb', sourceCode);
+		return makeRequest(url, {
+			method: 'POST',
+		});
 	}
 
 	return {

--- a/lib/api/nodeAbsorb.js
+++ b/lib/api/nodeAbsorb.js
@@ -1,7 +1,8 @@
 /**
+ * @param {string} baseUrl - the base url for absorb actions. Will be sent as '/v2/node' if no client options were provided.
  * @param {import('../BizOpsClient').FactoryOptions} options
  */
-function buildNodeAbsorb(options) {
+function buildNodeAbsorb(baseUrl, options) {
 	const { makeRequest } = options;
 
 	/**
@@ -16,7 +17,7 @@ function buildNodeAbsorb(options) {
 		sourceCode = encodeURIComponent(sourceCode);
 
 		return makeRequest(
-			`/v2/node/${type}/${targetCode}/absorb/${sourceCode}`,
+			`${baseUrl}/${type}/${targetCode}/absorb/${sourceCode}`,
 			{
 				method: 'POST',
 			},

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "nock": "^13.0.7"
       },
       "engines": {
-        "node": "18"
+        "node": ">= 18"
       }
     },
     "node_modules/@ampproject/remapping": {


### PR DESCRIPTION
## Why?

-   This library sends hardcoded endpoint names which stop us from being able to version the Biz Ops API `node` or `graphql` endpoints.

## What?

-   Allow `nodeEndpoint` as a client option - the default is `/v2/node`
- Allow `graphqlEndpoint` as a client option - the default is `/graphql`

### Anything in particular you'd like to highlight to reviewers?
- Once deployed this will allow users of new versions of the `node` and/or `graphql` methods of this library (mostly us in EI 😄 ) to be able to configure their Biz Ops client to send to a specific version of the Biz Ops API endpoints. 