### PR TITLE
[EI-4772] - Add support for batch PATCH and DELETE endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,22 @@ This method also accepts additional URL parameters to be set:
 
 Merges two records by copying properties from the source node to the target node and deletes the original source node when complete. Resolves with the updated target record if the request is successful. Rejects with a [`NotFound`](#errors) error if either of the requested records cannot be found.
 
+#### `batch.patch(type: string, body: object[], params?: object)`
+
+Creates or modifies a batch of records of a given record type.
+
+-   Requires its payload(records) to be sent as a JSON array
+-   Resolves with a success message and total number of records created or modified.
+-   Rejects with a [`HTTPError`](#errors) error if there is any payload validation error(s).
+
+#### `batch.delete(type: string, codes: object[], params?: object)`
+
+Deletes a batch of records of a given record type.
+
+-   Requires its payload(valid Biz ops codes) to be sent as a JSON array
+-   Resolves with a success message and total number of records deleted.
+-   Rejects with a [`HTTPError`](#errors) error if there is any payload validation error(s).
+
 #### `child(options?: object)`
 
 Sometimes you may need multiple instances of the client. You can do that by calling `new Client()` multiple times but you will lose the benefits of using one single client, such as the long lived connections and rate limiting. This method returns a new client instance that shares these internals with the parent client. You can override the parent client options by providing additional [options](#options).

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ The `BizOpsClient` class accepts the following parameters:
 | `host`            | String |          | URL for the Biz Ops API, defaults to `"https://api.ft.com/biz-ops"`.                                |
 | `nodeEndpoint`    | String | \*\*     | URL for the Biz Ops API node requests, defaults to `/v2/node`.                                      |
 | `graphqlEndpoint` | String | \*\*     | URL for the Biz Ops API graphql requests, defaults to `/graphql`.                                   |
+| `batchEndpoint`   | String | \*\*     | URL for the Biz Ops API batch requests, defaults to `/v1/batch`.                                    |
 | `timeout`         | Number |          | Maximum time in milliseconds to wait for a response, defaults to `15000`                            |
 | `rps`             | Number |          | Maximum number of API requests per second, defaults to `18` - highly recommended not to change this |
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ Creates or modifies a batch of records of a given record type.
 -   Resolves with a success message and total number of records created or modified.
 -   Rejects with a [`HTTPError`](#errors) error if there is any payload validation error(s).
 
+This method also accepts additional URL parameter to be set:
+
+`dryRun` a boolean(default `false`) which when set to `true` allows you to only just validate the request and the batch payload without performing the actual creation or modification of records
+
 #### `batch.delete(type: string, codes: object[], params?: object)`
 
 Deletes a batch of records of a given record type.
@@ -147,6 +151,10 @@ Deletes a batch of records of a given record type.
 -   Requires its payload(valid Biz ops codes) to be sent as a JSON array
 -   Resolves with a success message and total number of records deleted.
 -   Rejects with a [`HTTPError`](#errors) error if there is any payload validation error(s).
+
+This method also accepts additional URL parameter to be set:
+
+`dryRun` a boolean(default `false`) which when set to `true` allows you to only just validate the request and the batch payload without performing the actual deletion of records
 
 #### `child(options?: object)`
 

--- a/lib/BizOpsClient.js
+++ b/lib/BizOpsClient.js
@@ -1,6 +1,7 @@
 const buildNode = require('./api/node');
 const buildNodeAbsorb = require('./api/nodeAbsorb');
 const buildGraphQL = require('./api/graphQL');
+const buildBatch = require('./api/batch');
 const createTransport = require('./createTransport');
 const validateOptions = require('./utils/validateOptions');
 const { createAgent, createQueue } = require('./internals');
@@ -33,6 +34,7 @@ const defaultOptions = {
 	host: 'https://api.ft.com/biz-ops',
 	nodeEndpoint: '/v2/node',
 	graphqlEndpoint: '/graphql',
+	batchEndpoint: '/v1/batch',
 	timeout: 15000,
 	rps: 18,
 };
@@ -80,6 +82,7 @@ class BizOpsClient {
 			this.options.graphqlEndpoint,
 			apiFactoryOptions,
 		);
+		this.batch = buildBatch(this.options.batchEndpoint, apiFactoryOptions);
 	}
 
 	/**

--- a/lib/api/__tests__/batch.test.js
+++ b/lib/api/__tests__/batch.test.js
@@ -1,0 +1,137 @@
+const urlJoin = require('url-join');
+
+const subject = require('../batch');
+
+const patchPayload = [
+	{
+		code: 'code-1',
+		name: 'name-1',
+	},
+	{
+		code: 'code-2',
+		name: 'name-2',
+	},
+	{
+		code: 'code-3',
+		name: 'name-3',
+	},
+];
+const deletePayload = ['code-1', 'code-2', 'code-3'];
+const baseUrl = '/v1/batch';
+
+describe('lib/api/batch', () => {
+	const makeRequestMock = jest.fn();
+	const api = subject(baseUrl, { makeRequest: makeRequestMock });
+
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe('.patch()', () => {
+		it('should make a batch PATCH request', async () => {
+			const recordType = 'Type';
+			const params = { dryRun: true };
+
+			const expectedUrl = urlJoin(baseUrl, recordType, `?dryRun=true`);
+			const expectedRequestBody = JSON.stringify(patchPayload);
+
+			await api.patch(recordType, patchPayload, params);
+
+			expect(makeRequestMock).toHaveBeenCalledWith(expectedUrl, {
+				method: 'PATCH',
+				body: expectedRequestBody,
+			});
+		});
+
+		it('appends a body to the request', async () => {
+			makeRequestMock.mockResolvedValue({});
+
+			await api.patch('Type', patchPayload);
+
+			expect(makeRequestMock).toHaveBeenCalledWith(
+				`${baseUrl}/Type`,
+				expect.objectContaining({
+					method: 'PATCH',
+					body: JSON.stringify(patchPayload),
+				}),
+			);
+		});
+
+		it('appends a dryRun param if passed as a query string', async () => {
+			makeRequestMock.mockResolvedValue({});
+
+			await api.patch('Type', patchPayload, { dryRun: true });
+
+			expect(makeRequestMock).toHaveBeenCalledWith(
+				`${baseUrl}/Type?dryRun=true`,
+				expect.any(Object),
+			);
+		});
+
+		it('resolves with the response data', async () => {
+			const expectedResponse = {
+				message: 'Successfully created/updated all records',
+				numberOfRecords: 3,
+			};
+			makeRequestMock.mockResolvedValue(expectedResponse);
+
+			const response = await api.patch('Type', patchPayload);
+
+			expect(response).toEqual(expectedResponse);
+		});
+	});
+
+	describe('.delete()', () => {
+		it('should make a batch DELETE request', async () => {
+			const recordType = 'Type';
+			const params = { dryRun: true };
+
+			const expectedUrl = urlJoin(baseUrl, recordType, `?dryRun=true`);
+			const expectedRequestBody = JSON.stringify(deletePayload);
+
+			await api.delete(recordType, deletePayload, params);
+
+			expect(makeRequestMock).toHaveBeenCalledWith(expectedUrl, {
+				method: 'DELETE',
+				body: expectedRequestBody,
+			});
+		});
+
+		it('appends a body to the request', async () => {
+			makeRequestMock.mockResolvedValue({});
+
+			await api.delete('Type', deletePayload);
+
+			expect(makeRequestMock).toHaveBeenCalledWith(
+				`${baseUrl}/Type`,
+				expect.objectContaining({
+					method: 'DELETE',
+					body: JSON.stringify(deletePayload),
+				}),
+			);
+		});
+
+		it('appends a dryRun param if passed as a query string', async () => {
+			makeRequestMock.mockResolvedValue({});
+
+			await api.delete('Type', deletePayload, { dryRun: true });
+
+			expect(makeRequestMock).toHaveBeenCalledWith(
+				`${baseUrl}/Type?dryRun=true`,
+				expect.any(Object),
+			);
+		});
+
+		it('resolves with the response data', async () => {
+			const expectedResponse = {
+				message: 'Successfully deleted all records',
+				numberOfRecords: 2,
+			};
+			makeRequestMock.mockResolvedValue(expectedResponse);
+
+			const response = await api.delete('Type', deletePayload);
+
+			expect(response).toEqual(expectedResponse);
+		});
+	});
+});

--- a/lib/api/batch.js
+++ b/lib/api/batch.js
@@ -5,7 +5,7 @@ const queryString = require('../utils/queryString');
  * @param {string} baseUrl - the base url for node actions. Will default to '/v1/batch' if no `batchEndpoint` option is provided.
  * @param {import('../BizOpsClient').FactoryOptions} options
  */
-function buildPatch(baseUrl, options) {
+function buildBatch(baseUrl, options) {
 	const { makeRequest } = options;
 
 	/**
@@ -16,7 +16,7 @@ function buildPatch(baseUrl, options) {
 	 * @param {String} [params.dryRun] - perform a dry run of the operation
 	 * @returns {Promise<Object>}
 	 */
-	async function batchPatch(recordType, body, params = {}) {
+	async function patch(recordType, body, params = {}) {
 		const qs = queryString(params);
 
 		const url = urlJoin(baseUrl, recordType, `${qs ? '?' : ''}${qs}`);
@@ -47,9 +47,9 @@ function buildPatch(baseUrl, options) {
 	}
 
 	return {
-		patch: batchPatch,
+		patch,
 		delete: batchDelete,
 	};
 }
 
-module.exports = buildPatch;
+module.exports = buildBatch;

--- a/lib/api/batch.js
+++ b/lib/api/batch.js
@@ -1,0 +1,55 @@
+const urlJoin = require('url-join');
+const queryString = require('../utils/queryString');
+
+/**
+ * @param {string} baseUrl - the base url for node actions. Will default to '/v1/batch' if no `batchEndpoint` option is provided.
+ * @param {import('../BizOpsClient').FactoryOptions} options
+ */
+function buildPatch(baseUrl, options) {
+	const { makeRequest } = options;
+
+	/**
+	 * Make a Biz Ops API batch PATCH request to create or update batch of records
+	 * @param {String} recordType - The Biz Ops record type to create or update
+	 * @param {Object[]} body - JSON array of records to create or update
+	 * @param {Object} [params={}] - additional query string parameters
+	 * @param {String} [params.dryRun] - perform a dry run of the operation
+	 * @returns {Promise<Object>}
+	 */
+	async function batchPatch(recordType, body, params = {}) {
+		const qs = queryString(params);
+
+		const url = urlJoin(baseUrl, recordType, `${qs ? '?' : ''}${qs}`);
+
+		return makeRequest(url, {
+			method: 'PATCH',
+			body: JSON.stringify(body),
+		});
+	}
+
+	/**
+	 * Make a Biz Ops API batch DELETE request to delete batch of records
+	 * @param {String} recordType - The Biz Ops record type to delete
+	 * @param {String[]} codes - A JSON array of record codes to delete
+	 * @param {Object} [params={}] - additional query string parameters
+	 * @param {String} [params.dryRun] - perform a dry run of the operation
+	 * @returns {Promise<Object>}
+	 */
+	async function batchDelete(recordType, codes, params = {}) {
+		const qs = queryString(params);
+
+		const url = urlJoin(baseUrl, recordType, `${qs ? '?' : ''}${qs}`);
+
+		return makeRequest(url, {
+			method: 'DELETE',
+			body: JSON.stringify(codes),
+		});
+	}
+
+	return {
+		patch: batchPatch,
+		delete: batchDelete,
+	};
+}
+
+module.exports = buildPatch;


### PR DESCRIPTION
## Why?

-  We have added batch `PATCH` and `DELETE` endpoints to the API and the client needs to support that

## What?

- Adds support for batch `PATCH` and `DELETE` endpoints
- Add unit tests 